### PR TITLE
Update depdendency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ group = 'com.github.andygoossens'
 version = '1.9.4-SNAPSHOT'
 
 dependencies {
-    compileOnly 'org.gaul:modernizer-maven-plugin:2.7.0'
+    compileOnly 'org.gaul:modernizer-maven-plugin:2.9.0'
 }
 
 java {


### PR DESCRIPTION
Updates to https://github.com/gaul/modernizer-maven-plugin/releases/tag/modernizer-maven-plugin-2.9.0.

Should prepare the plugin for JDK 23.